### PR TITLE
Use React 16.0 to support all updated applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple-popover",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Popover component for React",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   "main": "lib/Popover.js",
   "dependencies": {
     "prop-types": "^15.6.0",
-    "react-overlays": "^0.6.5"
+    "react-overlays": "^0.8.3"
   },
   "devDependencies": {
     "babel": "^6.5.2",
@@ -20,8 +20,8 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.24.1",
-    "react": "^15.2.1",
-    "react-dom": "^15.2.1"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "scripts": {
     "test": "npm test",


### PR DESCRIPTION
Updated package.json to use latest dependant libraries in order to prevent any render issues for applications that are updated to React 16.0.

* `react-overlays: 0.8.3`
* `react: 16.0.0`
* `react-dom: 16.0.0`

New Version: `0.2.2`

Fixes issue https://github.com/dbtek/react-popover/issues/7