### PR TITLE
Modify PropTypes for Popover.js to prevent error during Webpack builds

### DIFF
--- a/lib/Popover.js
+++ b/lib/Popover.js
@@ -117,10 +117,10 @@ Popover.propTypes = {
   show: _propTypes2.default.bool.isRequired,
   onHide: _propTypes2.default.func,
   placement: _propTypes2.default.string,
-  target: _propTypes2.default.instanceOf(Node),
+  target: _propTypes2.default.object,
   style: _propTypes2.default.object,
   containerStyle: _propTypes2.default.object,
-  container: _propTypes2.default.element,
+  container: _propTypes2.default.object,
   hideWithOutsideClick: _propTypes2.default.bool,
   children: _propTypes2.default.element.isRequired
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple-popover",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Popover component for React",
   "repository": {
     "type": "git",

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -87,10 +87,10 @@ Popover.propTypes = {
   show: PropTypes.bool.isRequired,
   onHide: PropTypes.func,
   placement: PropTypes.string,
-  target: PropTypes.instanceOf(Node),
+  target: PropTypes.object,
   style: PropTypes.object,
   containerStyle: PropTypes.object,
-  container: PropTypes.element,
+  container: PropTypes.object,
   hideWithOutsideClick: PropTypes.bool,
   children: PropTypes.element.isRequired
 };


### PR DESCRIPTION
`Node is undefined error` is thrown for applications that use Webpack for bundling.

One reason could be due to the loss of the global context but how it is lost and how it could be retained is not yet investigated upon. Anyone who has expertise in this can chime in.

This fix is mainly focussed at un-blocking users for the time being.

`0.2.1` has introduced this bug when Proptypes are added in this
commit https://github.com/dbtek/react-popover/commit/fbd0b580304343a14a2b8ba0128fb774d539423c#diff-6b9279395755e9b3797ccf623cc31aabR86.

`container` propTypes are also changed because it's most likely that container is also a DOM element(**ref**) and will be an `instanceOf(Node)`

New Version: `0.2.3`

Fixes: https://github.com/dbtek/react-popover/issues/9